### PR TITLE
Add basic proof-of-concept hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,168 @@
+# dependent-jax
+
+Proof-of-concept implementation of dependent types for statically verifiable n-dimensional array operations with `jax` and `numpy` 
+by way of a [stubs only package](https://www.python.org/dev/peps/pep-0561/#stub-only-packages) 
+and [mypy plugin](https://mypy.readthedocs.io/en/stable/extending_mypy.html#extending-mypy-using-plugins).
+
+Note that this is very much a work in progress, and at present only a handful of operations are supported as a basic
+proof-of-concept.
+
+## What Is This?
+In most type systems there is a bright line between _types_ and _values_. Values are
+the stuff you assign to variables, e.g:
+- `42`
+- `"the string""`
+
+Types on the other hand are _sets of values_ that you talk about with your type-checker
+through type annotations and inference. Examples of types are:
+- `int` (to which the value `42` belongs)
+- `str` (to which the value `"the string"` belongs)
+
+[Dependent types](https://en.wikipedia.org/wiki/Dependent_type) blurs the line between values and types by allowing you to talk about values with your type checker. In Python
+this is done using the "[Literal](https://docs.python.org/3/library/typing.html#typing.Literal)" type:
+```python
+from typing import Literal
+
+
+FourtyTwo = Literal[42]  # Type alias for a type (i.e a set) that only contains the value 42
+x: FourtyTwo = 42
+y: FourtyTwo = 0  # Type error because 0 does not belong to the type 42
+```
+
+`dependent-jax` is a proof-of-concept of how to use `Literal` to annotate `jax.numpy.DeviceArray` and `numpy.ndarray` types
+with shape information, thereby providing _static verification of tensor operations_. In other words, `dependent-jax` helps `mypy`
+to catch many errors related to tensor shape mismatch that would otherwise turn up as
+runtime errors.
+
+
+`dependent-jax` currently demonstrates feasibility of the following types of annotations/inferences:
+
+- Annotating array types with shape information
+- Inferring shapes of arrays returned from functions that accept a `shape` parameter
+- Checking array shape compatibility and inferring shapes of arrays returned from binary broadcasting operations
+- Inferring shapes of arrays returned from unary operations
+- Checking array shape compatibility and inferring shapes of arrays returned from matrix multiplication
+- Inferring shapes of arrays returned from un-parameterized shape manipulation (e.g `array.flatten()`)
+- Inferring shapes of arrays returned from parameterized shape manipulation (e.g `array.reshape((...))`)
+- Checking argument compatibility and inferring shapes of arrays returned from index operations
+
+It should be possible to extend each of the approaches described above to many similar functions/methods
+in the `jax`/`numpy` api with little effort.
+## Install
+From github, e.g using `pip`:
+```commandline
+pip install git+https://github.com/suned/dependent-jax
+```
+Add the following to your [mypy config file](https://mypy.readthedocs.io/en/stable/config_file.html) to enable the mypy plugin (this package doesn't make any sense without it):
+```
+[mypy]
+plugins = dependent_jax
+```
+## Usage
+When instantiating arrays from io or from Python values (e.g `list` instances), there
+is no way to infer the array shape, and it should be supplied via annotation. `jax.numpy.DeviceArray` and `numpy.ndarray` accepts at
+minimum two type paramaters. All type parameters to `jax.numpy.DeviceArray` and `numpy.ndarray` except the last must be `Literal` integer types. The last type parameter is always the scalar type of the array:
+```python
+from typing import Literal
+
+import jax.numpy as jnp
+import numpy as np
+
+
+a: jnp.DeviceArray[Literal[3], Literal[2], jnp.float32] = jnp.array([[1, 2], [3, 4], [5, 6]])
+b: np.ndarray[Literal[3], Literal[2], np.float64] = np.array([[1, 2], [3, 4], [5, 6]])
+
+reveal_type(a)  # note: Revealed type is "jax.numpy.DeviceArray[Literal[3], Literal[2], jax.numpy.float32]"
+reveal_type(b)  # note: Revealed type is "numpy.ndarray[Literal[3], Literal[2], numpy.float64]"
+```
+
+`typing.Any` in the place of the shape variable(s) always indicates an array of unknown shape:
+
+```python
+import jax.numpy as jnp
+
+
+reveal_type(jnp.array([]))  # note: Revealed type is "jax.numpy.DeviceArray[Any, jax.numpy.float32]"
+```
+
+When instantiating arrays with functions that take a shape parameter,
+the resulting shape can be inferred provided that the shape arguments are
+literal types:
+```python
+import jax.numpy as jnp
+
+
+a = jnp.zeros((2, 2))
+reveal_type(a)  # Revealed type is: jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32)
+```
+
+With `mypy`, values can be interpreted as literal types when:
+- The value is supplied directly as an argument (e.g `jnp.zeros((2, 2))`)
+- A variable is annotated with `Literal` (e.g `two: Literal[2] = 2`)
+- A variable is annotated with `Final` (e.g `two: Final = 2`)
+
+This means that the return type of `jnp.zeros` can be inferred in the following examples:
+
+```python
+from typing import Literal, Final
+
+import jax.numpy as jnp
+
+
+a: Literal[2] = 2
+b: Final = 2
+
+jnp.zeros((2, 2))
+jnp.zeros((a, a))
+jnp.zeros((b, b))
+```
+
+but not in:
+
+```python
+import jax.numpy as jnp
+
+
+a = 2
+jnp.zeros((a, a))
+```
+
+The shape of arrays resulting from operations on arrays with known shape can be inferred, and errors
+resulting from incompatible dimensions will be reported by `mypy`:
+
+```python
+import jax.numpy as jnp
+
+
+a: jnp.DeviceArray[Literal[3], Literal[2], jnp.float32]
+b: jnp.DeviceArray[Literal[2], Literal[1], jnp.float32]
+
+reveal_type(a @ b)  # Revealed type is: jax.numpy.DeviceArray[Literal[3], Literal[1], np.float32]
+```
+The shape of arrays resulting from index operations can currently only be inferred when
+the types of arguments are either:
+
+- Literal integers
+- In-line slice expressions
+- `Tuple` types with literal integer element types in the case of [advanced indexing](https://numpy.org/doc/stable/reference/arrays.indexing.html#advanced-indexing)
+
+For example in:
+```python
+from typing import Final
+
+import jax.numpy as jnp
+
+
+zero: Final = 0
+a = jnp.zeros((3, 2))
+
+reveal_type(a[0])    # Revealed type is: jax.numpy.DeviceArray[Literal[2], jax.numpy.float32] 
+reveal_type(a[zero:2])  # Revealed type is: jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32]
+```
+
+But not in:
+```python
+s = slice(0, 1)
+# Inference of index operations with slices only works with in-line slice expressions
+reveal_type(a[s])    # Revealed type is: jax.numpy.DeviceArray[Any, jax.numpy.float32]
+```

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,79 @@
+from typing import Dict
+import tokenize
+import re
+import difflib
+
+import pytest
+import _pytest
+from mypy.api import run
+
+
+def pytest_collect_file(parent, path):
+    if path.ext == ".pyi" and path.basename.startswith("test"):
+        return StubFile.from_parent(parent, fspath=path)
+
+
+class StubFile(pytest.File):
+    def check_file(self, filename: str) -> Dict[int, str]:
+        pattern = r'(?P<file>.+):(?P<line>\d+): (?P<msg>.+)'
+        end_pattern = r'Found \d+ errors? in \d+ file \(checked \d+ source files?\)'
+        stdout, stderr, _ = run([filename, '--show-traceback', '--raise-exceptions'])
+        lines = {}
+        for line in stdout.splitlines() + stderr.splitlines():
+            if re.match(end_pattern, line):
+                continue
+            m = re.match(pattern, line)
+            lines[int(m.group('line'))] = m.group('msg')
+        return lines
+
+    def get_comments(self, filename: str):
+        comments = {}
+        with open(filename) as f:
+            for toktype, tok, start, end, line in tokenize.generate_tokens(f.readline):
+                if toktype == tokenize.COMMENT and re.search(r'^# ?note|error: .+', tok):
+                    comments[start[0]] = re.sub(r'^# ?', '', tok)
+        return comments
+
+    def collect(self):
+        output = self.check_file(str(self.fspath))
+        comments = self.get_comments(str(self.fspath))
+        for line, msg in output.items():
+            name = f'{self.fspath.basename}:{line}'
+            if line not in comments:
+                yield StubItem.from_parent(parent=self, name=name, line=line, msg=msg, comment='')
+            else:
+                yield StubItem.from_parent(parent=self, name=name, line=line, msg=msg, comment=comments[line])
+        for line, comment in comments.items():
+            if line in output:
+                continue
+            name = f'{self.fspath.basename}:{line}'
+            yield StubItem.from_parent(parent=self, name=name, line=line, msg='', comment=comment)
+
+
+class MypyRepr(_pytest._code.code.TerminalRepr):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def toterminal(self, tw):
+        tw.line(self.msg, bold=True, red=True)
+
+
+class StubItem(pytest.Item):
+    def __init__(self, name, parent, msg, comment, line):
+        super().__init__(name, parent)
+        self.msg = msg
+        self.comment = comment
+        self.line = line
+
+    def runtest(self):
+        if self.msg == '':
+            error_msg = f'No output on line {self.line}'
+        else:
+            error_msg = f"Unexpected mypy output on line {self.line}"
+        assert self.msg == self.comment, error_msg
+
+    def repr_failure(self, excinfo, *args, **kwargs):
+        return MypyRepr(excinfo.exconly())
+
+    def reportinfo(self):
+        return self.fspath, 0, self.name

--- a/jax-stubs/numpy.pyi
+++ b/jax-stubs/numpy.pyi
@@ -1,0 +1,93 @@
+from typing import Tuple, Any, Type, TypeVar, overload, Union, Sequence, Generic
+
+import numpy as np
+
+
+class float32:
+    pass
+
+
+class int32:
+    pass
+
+
+DType = Union[float32, int32, np.DType]
+
+newaxis = None
+
+
+ArrayLike = Union[Sequence, int, float, bool, str, complex, bytes, DType, np.SupportsArray]
+
+D = TypeVar('D', bound=DType, covariant=True)
+S = TypeVar('S')
+
+Self = TypeVar('Self')
+
+A = TypeVar('A', bound=ArrayLike)
+
+
+class DeviceArray(Generic[S, D]):
+    def __pos__(self: Self) -> Self:
+        pass
+
+    def __add__(self, other: A) -> DeviceArray:
+        pass
+
+    def __matmul__(self, other: A) -> DeviceArray:
+        pass
+
+    def flatten(self, order: Literal['C', 'F', 'A', 'K'] = 'C') -> DeviceArray[Any, D]:
+        pass
+
+    def reshape(self, shape: Union[int, Tuple[int, ...]], order: Literal['C', 'F', 'A'] = 'C') -> DeviceArray[Any, D]:
+        pass
+
+    @overload
+    def __getitem__(self, item: int) -> DeviceArray:
+        pass
+
+    @overload
+    def __getitem__(self, item: slice) -> DeviceArray:
+        pass
+
+    @overload
+    def __getitem__(self, item: np.SupportsIndex) -> DeviceArray:
+        pass
+
+    @overload
+    def __getitem__(self, item: Sequence) -> DeviceArray:
+        pass
+
+    @overload
+    def __getitem__(self, item: builtins.ellipsis) -> DeviceArray:
+        pass
+
+    @overload
+    def __getitem__(self, item: None) -> DeviceArray:
+        pass
+
+    @overload
+    def __getitem__(self, item: np.ndarray) -> DeviceArray:
+        pass
+
+    @overload
+    def __getitem__(self, item: DeviceArray) -> DeviceArray:
+        pass
+
+
+@overload
+def zeros(shape: Tuple[int, ...], dtype: Type[D]) -> DeviceArray[Any, D]:
+    pass
+
+@overload
+def zeros(shape: Tuple[int, ...]) -> DeviceArray[Any, float32]:
+    pass
+
+
+@overload
+def array(object: A, dtype: Type[D]) -> DeviceArray[Any, D]:
+    pass
+
+@overload
+def array(object: A) -> DeviceArray[Any, float32]:
+    pass

--- a/numpy-stubs/__init__.pyi
+++ b/numpy-stubs/__init__.pyi
@@ -1,0 +1,261 @@
+import builtins
+from typing import Any, Tuple, TypeVar, Type, overload, Union, Generic, final, Iterable, Sequence, Protocol, Literal
+
+
+class generic:
+    pass
+
+
+class bool_(generic):
+    pass
+
+
+class object_(generic):
+    pass
+
+
+class number(generic):
+    pass
+
+
+class integer(number):
+    pass
+
+
+class inexact(number):
+    ...
+
+
+class flexible(generic):
+    pass
+
+
+# ---------------------------------- signed integers -----------------------------------
+
+class signedinteger(integer):
+    pass
+
+
+class int64(signedinteger):
+    ...
+
+
+class int32(signedinteger):
+    ...
+
+
+class int16(signedinteger):
+    ...
+
+
+class int8(signedinteger):
+    ...
+
+
+# --------------------------------- unsigned integers ----------------------------------
+
+class unsignedinteger(integer):
+    ...
+
+
+class uint64(unsignedinteger):
+    ...
+
+
+class uint32(unsignedinteger):
+    ...
+
+
+class uint16(unsignedinteger):
+    ...
+
+
+class uint8(unsignedinteger):
+    ...
+
+
+# ------------------------------------- floating ---------------------------------------
+
+
+class floating(inexact):
+    ...
+
+
+class float96(floating):
+    ...
+
+
+class float128(floating):
+    ...
+
+
+class float64(floating):
+    ...
+
+
+class float32(floating):
+    ...
+
+
+class float16(floating):
+    ...
+
+
+class float8(floating):
+    ...
+
+
+# --------------------------------- complex floating -----------------------------------
+
+class complexfloating(inexact):
+    ...
+
+
+class complex64(complexfloating):
+    ...
+
+
+class complex128(complexfloating):
+    ...
+
+
+class complex192(complexfloating):
+    ...
+
+
+class complex256(complexfloating):
+    ...
+
+
+# ------------------------------------- flexible ---------------------------------------
+
+class void(flexible):
+    pass
+
+
+class character(flexible):
+    pass
+
+
+class str_(flexible):
+    pass
+
+
+DType = Union[float64,
+              float32,
+              float16,
+              float8,
+
+              int64,
+              int32,
+              int16,
+              int8,
+
+              uint8,
+              uint16,
+              uint32,
+              uint64,
+
+              bool_,
+
+              complex64,
+              complex128,
+              complex192,
+              complex256,
+
+              void,
+
+              str_]
+
+S = TypeVar('S')
+D = TypeVar('D', bound=DType, covariant=True)
+D2 = TypeVar('D2')
+Self = TypeVar('Self')
+
+
+class SupportsIndex(Protocol):
+    def __index__(self) -> Union[int, slice]:
+        pass
+
+
+newaxis = None
+
+
+ArrayIndex = Union[int, bool, slice, SupportsIndex, Sequence, None, builtins.ellipsis]
+ArrayLike = Union[Sequence, int, float, bool, str, complex, bytes, DType, SupportsArray]
+A = TypeVar('A', bound=ArrayLike)
+
+
+class ndarray(Generic[S, D], Sequence):
+
+    def __add__(self, other: A) -> ndarray[Any, Any]:
+        pass
+
+    def __matmul__(self, other: A) -> ndarray[Any, Any]:
+        pass
+
+    def __pos__(self: Self) -> Self:
+        pass
+
+
+    @overload
+    def __getitem__(self, item: int) -> ndarray:
+        pass
+
+    @overload
+    def __getitem__(self, item: slice) -> ndarray:
+        pass
+
+    @overload
+    def __getitem__(self, item: SupportsIndex) -> ndarray:
+        pass
+
+    @overload
+    def __getitem__(self, item: Sequence) -> ndarray:
+        pass
+
+    @overload
+    def __getitem__(self, item: builtins.ellipsis) -> ndarray:
+        pass
+
+    @overload
+    def __getitem__(self, item: None) -> ndarray:
+        pass
+
+    @overload
+    def __getitem__(self, item: ndarray) -> ndarray:
+        pass
+
+    def flatten(self, order: Literal['C', 'F', 'A', 'K'] = 'C') -> ndarray[Any, D]:
+        pass
+
+    def reshape(self, shape: Union[int, Tuple[int, ...]], order: Literal['C', 'F', 'A'] = 'C') -> ndarray[Any, D]:
+        pass
+
+    def __len__(self) -> int:
+        pass
+
+
+@overload
+def zeros(shape: Tuple[int, ...]) -> ndarray[Any, float64]:
+    pass
+
+
+@overload
+def zeros(shape: Tuple[int, ...], dtype: Type[D]) -> ndarray[Any, D]:
+    pass
+
+
+class SupportsArray(Protocol):
+    def __array__(self) -> ndarray:
+        ...
+
+
+@overload
+def array(object: A, dtype: Type[D]) -> ndarray[Any, D]:
+    pass
+
+
+@overload
+def array(object: A) -> ndarray[Any, float64]:
+    pass

--- a/pax/__init__.py
+++ b/pax/__init__.py
@@ -1,0 +1,544 @@
+from typing import Optional, Callable, List, Union, Type as Type_, Any, Dict
+from typing_extensions import TypeGuard
+import itertools
+import functools
+import re
+
+import numpy as np
+import jax.numpy as jnp
+
+from mypy.types import Type, Instance, LiteralType, AnyType, TupleType, TypeVarType, CallableType, TypeVarDef, TypeVarId, NoneType, EllipsisType
+from mypy.mro import calculate_mro
+from mypy.nodes import TypeInfo, SymbolTable, ClassDef, Block, Argument, Var, ARG_POS, FuncDef, PassStmt, SymbolTableNode, MDEF, INVARIANT, SliceExpr, Node, MypyFile
+from mypy.semanal import set_callable_name
+from mypy.typeops import get_proper_type, fill_typevars
+from mypy.util import get_unique_redefinition_name
+from mypy.type_visitor import TypeQuery
+from mypy.subtypes import is_subtype
+from mypy.plugin import Plugin, FunctionContext, AnalyzeTypeContext, TypeAnalyzerPluginInterface, MethodContext, SemanticAnalyzerPluginInterface, CheckerPluginInterface
+from mypy.lookup import lookup_fully_qualified
+
+
+class IncompatibleBroadcastDimensionsError(Exception):
+    def __init__(self, first_dimension, second_dimension):
+        self.first_dimension = first_dimension
+        self.second_dimension = second_dimension
+
+
+class IncompatibleBroadcastDimensionsForArraysError(Exception):
+    def __init__(self, first_array, second_array, first_dimension, second_dimension):
+        self.first_array = first_array
+        self.second_array = second_array
+        self.first_dimension = first_dimension
+        self.second_dimension = second_dimension
+
+
+def get_dtype(fullname: str, first: Instance, second: Instance, modules) -> Optional[Instance]:
+    # this is an awful solution. Should be implemented purely in terms
+    # of mypy types, in order to avoid importing numpy and jax
+    module_name, *_ = fullname.split('.')
+    if module_name == 'numpy':
+        module = np
+    else:
+        module = jnp
+        module_name = 'jax.numpy'
+    first_dtype = getattr(module, first.type.name)(0)
+    second_dtype = getattr(module, second.type.name)(0)
+    try:
+        result = first_dtype + second_dtype
+        dtype_name = f'{module_name}.{result.dtype.name}'
+        dtype_info = lookup_fully_qualified(dtype_name, modules).node
+        return Instance(dtype_info, [])
+    except:
+        return None
+
+
+def _type_var_def(
+    name: str,
+    module: str,
+    upper_bound: Type,
+    values=(),
+    meta_level: int = 0,
+    variance: int = INVARIANT
+) -> TypeVarDef:
+    id_ = TypeVarId.new(meta_level)
+    fullname = f'{module}.{name}'
+    return TypeVarDef(name, fullname, id_, list(values), upper_bound, variance)
+
+
+def analyze_array_hook(ctx: AnalyzeTypeContext, fullname: str) -> Type:
+    analyzer: TypeAnalyzerPluginInterface = ctx.api
+    if not ctx.type.args:
+        args = [AnyType(0), AnyType(0)]
+    else:
+        args = [analyzer.analyze_type(arg) for arg in ctx.type.args]
+        args = [get_proper_type(arg) for arg in args]
+    *dims, type_ = args
+    if not all(isinstance(dim, LiteralType) or isinstance(dim, AnyType) for dim in dims):
+        analyzer.fail(f'All dimensions of {fullname} must be Literal types', ctx.type)
+    elif any(type(dim.value) is not int for dim in dims if isinstance(dim, LiteralType)):
+        analyzer.fail(
+            f'All arguments of literals in dimensions of {fullname} must be int',
+            ctx.type)
+    ndarray = array_instance(fullname, args, ctx.type.line, ctx.type.column, ctx.api.api.modules, ctx.api.named_type('builtins.object'))
+    return ndarray
+
+
+def array_instance(fullname: str, args: List[Type], line: int, column: int, modules: Dict[str, MypyFile], object_type: Instance) -> Instance:
+    array_info = lookup_fully_qualified(fullname, modules).node
+    array = Instance(array_info, args, line=line, column=column)
+    add_type_vars_to_array(array, object_type)
+    return array
+
+
+def ndarray_hook(ctx: AnalyzeTypeContext) -> Type:
+    return analyze_array_hook(ctx, 'numpy.ndarray')
+
+
+def device_array_hook(ctx: AnalyzeTypeContext) -> Type:
+    return analyze_array_hook(ctx, 'jax.numpy.DeviceArray')
+
+
+def add_type_vars_to_array(ndarray: Instance, upper_bound: Type) -> None:
+    type_var_names = [f'S{i + 1}' for i in range(len(ndarray.args) - 1)]
+    type_var_defs = [_type_var_def(name, 'numpy', upper_bound)
+                     for name in type_var_names]
+    defn = ClassDef(ndarray.type.defn.name,
+                    ndarray.type.defn.defs,
+                    [*type_var_defs, ndarray.type.defn.type_vars[-1]],
+                    ndarray.type.defn.base_type_exprs,
+                    ndarray.type.defn.metaclass)
+    defn.fullname = ndarray.type.defn.fullname
+    type = TypeInfo(ndarray.type.names, defn, ndarray.type.module_name)
+    calculate_mro(type)
+    ndarray.type = type
+
+
+def is_array_type(t: Type) -> TypeGuard[Instance]:
+    return isinstance(t, Instance) and t.type.fullname in ('numpy.ndarray', 'jax.numpy.DeviceArray')
+
+
+def is_list_of_literals(ts: List[Type]) -> TypeGuard[List[LiteralType]]:
+    return all(isinstance(t, LiteralType) for t in ts)
+
+
+def check_broadcast_operation(first_dims: List[LiteralType], second_dims: List[LiteralType], api: CheckerPluginInterface) -> List[Type]:
+    ret_dims = []
+    for self_dim, other_dim in itertools.zip_longest(reversed(first_dims),
+                                                     reversed(second_dims),
+                                                     fillvalue=LiteralType(1, api.named_type('builtins.int'))):
+        is_1 = self_dim.value == 1 or other_dim.value == 1
+        are_equal = self_dim == other_dim
+        if not is_1 and not are_equal:
+            raise IncompatibleBroadcastDimensionsError(self_dim, other_dim)
+        if are_equal:
+            ret_dims.append(self_dim)
+        else:
+            # one dimension was 1
+            ret_dims.append(max(self_dim, other_dim, key=lambda dim: dim.value))
+    ret_dim_literals_ordered = reversed(ret_dims)
+    return list(ret_dim_literals_ordered)
+
+
+def check_ndarray_operation(fullname: str, first: Instance, second: Instance, operation: str, ctx: MethodContext) -> Type:
+    *self_dims, self_type = first.args
+    *other_dims, other_type = second.args
+    ret_type = get_dtype(fullname, self_type, other_type, ctx.api.modules)
+    if ret_type is None:
+        ctx.api.fail(f'Incompatible scalar types ("{self_type}" and "{other_type}")', ctx.context)
+        return ctx.default_return_type
+    default_return_type = ctx.default_return_type.copy_modified(
+        args=[AnyType(0), ret_type])
+    if any(isinstance(dim, AnyType) for dim in self_dims):
+        return first
+    if any(isinstance(dim, AnyType) for dim in other_dims):
+        return second
+    if not is_list_of_literals(self_dims) or not is_list_of_literals(other_dims):
+        return default_return_type
+    try:
+        ret_dims = check_broadcast_operation(self_dims, other_dims, ctx.api)
+    except IncompatibleBroadcastDimensionsError as e:
+        msg = (f'Unsupported operand type for {operation} '
+               f'("{first}" and "{second}" because '
+               f'dimensions {e.first_dimension} and {e.second_dimension} are incompatible)')
+        ctx.api.fail(msg, ctx.context)
+        ret_dims = [AnyType(0)]
+
+    array = array_instance(fullname, [*ret_dims, ret_type], -1, -1, ctx.api.modules, ctx.api.named_type('builtins.object'))
+    return array
+
+
+def is_supported_builtin_operand_type(t: Type) -> TypeGuard[Instance]:
+    return isinstance(t, Instance) and t.type.fullname in ('builtins.int', 'builtins.float')
+
+
+def check_operation_with_builtin_type(first: Instance, second: Instance, operation: str, ctx: MethodContext) -> Type:
+    # TODO map result dtype based on operand
+    return first
+
+
+def add_hook(fullname: str, ctx: MethodContext) -> Type:
+    self = ctx.type
+    other = ctx.arg_types[0][0]
+    if is_array_type(other):
+        return check_ndarray_operation(fullname, self, other, '+', ctx)
+    elif is_supported_builtin_operand_type(other):
+        return check_operation_with_builtin_type(self, other, '+', ctx)
+    else:
+        ctx.api.msg.unsupported_operand_types('+', self, other, ctx.context)
+        return ctx.default_return_type
+
+
+def is_literal_instance(t: Type) -> bool:
+    return isinstance(t, Instance) and t.last_known_value is not None
+
+
+def is_list_of_literal_instances(ts: List[Type]) -> bool:
+    return all(is_literal_instance(t) for t in ts)
+
+
+def zeros_hook(ctx: FunctionContext) -> Type:
+    shape = ctx.arg_types[0][0]
+    if not isinstance(shape, TupleType):
+        return ctx.default_return_type
+    if not all(is_literal_instance(item) or isinstance(item, LiteralType) for item in shape.items):
+        return ctx.default_return_type
+    args = [item.last_known_value if not isinstance(item, LiteralType) else item for item in shape.items]  # type: ignore
+    *_, type_ = ctx.default_return_type.args
+    return ctx.default_return_type.copy_modified(args=[*args, type_])
+
+
+def matmul_hook(fullname: str, ctx: MethodContext) -> Type:
+    #import ipdb; ipdb.set_trace()
+    *self_dims, self_type = ctx.type.args
+    *other_dims, other_type = ctx.arg_types[0][0].args
+    ret_type = get_dtype(fullname, self_type, other_type, ctx.api.modules)
+    int_type = ctx.api.named_type('builtins.int')
+    if not is_list_of_literals(self_dims) or not is_list_of_literals(other_dims):
+        return AnyType(0)
+    prepended = False
+    appended = False
+    if len(self_dims) == 1:
+        self_dims = [LiteralType(1, int_type), *self_dims]
+        prepended = True
+    if len(other_dims) == 1:
+        other_dims = [*other_dims, LiteralType(1, int_type)]
+        appended = True
+    if self_dims[-1] != other_dims[-2]:
+        ctx.api.fail(f'Unsupported operand type for @ ("{ctx.type}" and "{ctx.arg_types[0][0]}" because dimensions {self_dims[-1]} and {other_dims[-2]} are incompatible)', ctx.context)
+        return ctx.default_return_type.copy_modified(args=[AnyType(0), ret_type])
+    try:
+        ret_dims = check_broadcast_operation(self_dims[:-1], other_dims[:-2], ctx.api)
+    except IncompatibleBroadcastDimensionsError as e:
+        msg = (f'Unsupported operand type for @ '
+               f'("{ctx.type}" and "{ctx.arg_types[0][0]}" because '
+               f'dimensions {e.first_dimension} and {e.second_dimension} are incompatible)')
+        ctx.api.fail(msg, ctx.context)
+        ret_dims = [AnyType(0)]
+    else:
+        ret_dims = [*ret_dims, other_dims[-1]]
+    if prepended:
+        ret_dims = ret_dims[1:]
+    if appended:
+        ret_dims = ret_dims[:-1]
+    if not ret_dims:
+        return ret_type
+    array = array_instance(fullname, [*ret_dims, ret_type], -1, -1, ctx.api.modules, ctx.api.named_type('builtins.object'))
+    return array
+
+
+def array_hook(ctx: FunctionContext) -> Type:
+    # todo infer return dtype with recursive sequences
+    return ctx.default_return_type
+
+
+def get_total_size(dims: List[LiteralType]) -> int:
+    return functools.reduce(lambda result, dim: result * dim.value, dims, 1)
+
+
+def flatten_hook(ctx: MethodContext) -> Type:
+    *dims, type_ = ctx.type.args
+    if not is_list_of_literals(dims):
+        return ctx.default_return_type
+    new_shape = get_total_size(dims)
+    new_shape_literal = LiteralType(new_shape, ctx.api.named_type('builtins.int'))
+    return ctx.default_return_type.copy_modified(args=[new_shape_literal, type_])
+
+
+def reshape_hook(ctx: MethodContext) -> Type:
+    *dims, type_ = ctx.type.args
+    shape = ctx.arg_types[0][0]
+    if not is_list_of_literals(dims):
+        return ctx.default_return_type
+    total_size = get_total_size(dims)
+    if isinstance(shape, TupleType):
+        if not all(is_literal_instance(item) or isinstance(item, LiteralType) for item in shape.items):
+            return ctx.default_return_type
+        args = [item.last_known_value if is_literal_instance(item) else item for item in shape.items]
+        requested_size = get_total_size(args)
+    elif is_literal_instance(shape):
+        arg = shape.last_known_value
+        args = [arg]
+        requested_size = arg.value
+    else:
+        return ctx.default_return_type
+    if requested_size != total_size:
+        ctx.api.fail(f'Can\'t reshape "{ctx.type}" into shape "{args}"', ctx.context)
+        return ctx.default_return_type
+    return ctx.default_return_type.copy_modified(args=[*args, type_])
+
+
+def is_scalar_type(t: Type, *names: str) -> bool:
+    return isinstance(t, Instance) and t.type.fullname in names
+
+
+def check_broadcast_operations(arrays: List[Instance], api) -> List[LiteralType]:
+    first, *rest = arrays
+    *first_dims, _ = first.args
+    result_dims = first_dims
+    for array in rest:
+        *second_dims, _ = array.args
+        result_dims = check_broadcast_operation(first_dims, second_dims, api)
+    return result_dims
+
+
+def ndarray(dims: List[LiteralType], scalar: Instance, api) -> Instance:
+    args = [*dims, scalar]
+    ndarray = api.named_generic_type('numpy.ndarray', args)
+    object = api.named_type('builtins.object')
+    add_type_vars_to_array(ndarray, object)
+    return ndarray
+
+
+def advanced_indexing(indices: List[Type], dims: List[Type], index_exprs: List[Node], type_: Type, ctx: MethodContext) -> Type:
+    array_indices = []
+    advanced_indices = []
+    result_dims = []
+    for dim_index, (dim, expr, index) in enumerate(zip(dims, index_exprs, indices)):
+        if is_array_type(index):
+            advanced_indices.append(dim_index)
+            *index_dims, index_type = index.args
+            integer_type = ctx.api.named_type('numpy.integer')
+            bool_type = ctx.api.named_type('numpy.bool_')
+            if not (is_subtype(index_type, integer_type) or is_subtype(index_type, bool_type)):
+                ctx.api.fail('Arrays used as indices must be of integer (or boolean) type', ctx.context)
+                return ctx.default_return_type
+            if not is_list_of_literals(index_dims):
+                return ctx.default_return_type
+            array_indices.append(index)
+        elif isinstance(index, TupleType):
+            advanced_indices.append(dim_index)
+            if not all(is_literal_instance(i) or isinstance(i, LiteralType) for i in index.items):
+                return ctx.default_return_type
+            index_indices = [
+                i.last_known_value if is_literal_instance(i) else i for i in
+                index.items]
+            for i in index_indices:
+                if i.value >= dim.value:
+                    ctx.api.fail(f'Index {i.value} is out of bounds for axis with size {dim.value}', ctx.context)
+                    return ctx.default_return_type
+            array = ndarray(
+                [LiteralType(len(index_indices), ctx.api.named_type('builtins.int'))],
+                type_,
+                ctx.api
+            )
+            array_indices.append(array)
+        elif is_literal_instance(index) or isinstance(index, LiteralType):
+            advanced_indices.append(dim_index)
+            index_value = index.value if isinstance(index, LiteralType) else index.last_known_value.value
+            if index_value >= dim.value:
+                ctx.api.fail(f'Index {index_value} is out of bounds for axis with size {dim.value}', ctx.context)
+                return ctx.default_return_type
+            array = ndarray(
+                [LiteralType(1, ctx.api.named_type('builtins.int'))],
+                type_,
+                ctx.api
+            )
+            array_indices.append(array)
+        elif is_slice(index):
+            return_dim = get_slice_return_dim(expr, dim, ctx)
+            if return_dim is None:
+                return ctx.default_return_type
+            result_dims.append(return_dim)
+        elif isinstance(index, NoneType):
+            result_dims.append(LiteralType(1, ctx.api.named_type('builtins.int')))
+        else:
+            return ctx.default_return_type
+    try:
+        broadcasted_dims = check_broadcast_operations(array_indices, ctx.api)
+        advanced_indices_are_next_to_eachother = advanced_indices == list(range(min(advanced_indices), max(advanced_indices) + 1))
+        if advanced_indices_are_next_to_eachother:
+            first_advanced_index = min(advanced_indices)
+            broadcasted_indices = range(first_advanced_index, first_advanced_index + len(broadcasted_dims) + 1)
+            for i, broadcasted_dim in zip(broadcasted_indices, broadcasted_dims):
+                result_dims.insert(i, broadcasted_dim)
+        else:
+            result_dims = broadcasted_dims + result_dims
+        return ctx.default_return_type.copy_modified(args=[*result_dims, type_])
+    except IncompatibleBroadcastDimensionsError:
+        # todo better message
+        ctx.api.fail('broadcast error', ctx.context)
+        return ctx.default_return_type
+
+
+def is_ellipsis(t: Type) -> bool:
+    return isinstance(t, Instance) and t.type.fullname == 'builtins.ellipsis'
+
+
+def is_slice(t: Type) -> bool:
+    return isinstance(t, Instance) and t.type.fullname == 'builtins.slice'
+
+
+def get_slice_return_dim(index_expr: Node, dim: LiteralType, ctx: MethodContext) -> Optional[LiteralType]:
+    if not isinstance(index_expr, SliceExpr):
+        return None
+    if not (index_expr.begin_index or index_expr.end_index):
+        return dim
+    else:
+        if index_expr.end_index:
+            end_index_type = index_expr.end_index.accept(ctx.api.expr_checker)
+            if not end_index_type.last_known_value:
+                return None
+            end_index = end_index_type.last_known_value.value
+        else:
+            end_index = dim.value
+        if index_expr.begin_index:
+            begin_index_type = index_expr.begin_index.accept(ctx.api.expr_checker)
+            if not begin_index_type.last_known_value:
+                return None
+            begin_index = begin_index_type.last_known_value.value
+        else:
+            begin_index = 0
+        return LiteralType(
+            min(len(range(begin_index, end_index)), dim.value),
+            ctx.api.named_type('builtins.int')
+        )
+
+
+def get_item_hook(ctx: MethodContext) -> Type:
+    arg = ctx.arg_types[0][0]
+    self = ctx.type
+    *dims, type_ = self.args
+    if not is_list_of_literals(dims):
+        return ctx.default_return_type
+
+    if isinstance(arg, (Instance, LiteralType)):
+        indices = [arg]
+        index_exprs = [ctx.args[0][0]]
+    elif isinstance(arg, TupleType):
+        indices = arg.items
+        index_exprs = ctx.args[0][0].items
+    else:
+        return ctx.default_return_type
+
+    real_indices = [i for i in indices if not isinstance(i, NoneType) and not is_ellipsis(i)]
+
+    if len(real_indices) > len(dims):
+        ctx.api.fail(f'Too many indices: array is {len(dims)}-dimensional, but {len(real_indices)} were indexed', ctx.context)
+        return ctx.default_return_type
+
+    ellipses = [i for i in indices if is_ellipsis(i)]
+
+    if len(ellipses) > 1:
+        ctx.api.fail('An index can only have a single ellipsis (\'...\')', ctx.context)
+        return ctx.default_return_type
+    if len(ellipses) == 1:
+        diff = len(dims) - len(real_indices)
+        ellipsis_index = next(i for i, index in enumerate(indices) if is_ellipsis(index))
+
+        indices_before, indices_after = indices[:ellipsis_index], indices[ellipsis_index + 1:]
+        indices = indices_before + [ctx.api.named_type('builtins.slice')] * diff + indices_after
+
+        index_exprs_before, index_exprs_after = index_exprs[:ellipsis_index], index_exprs[ellipsis_index + 1:]
+        index_exprs = index_exprs_before + [SliceExpr(None, None, None)] * diff + index_exprs_after
+
+    if len(real_indices) < len(dims) and len(ellipses) == 0:
+        indices.extend(ctx.api.named_type('builtins.slice') for _ in range(len(dims) - len(real_indices)))
+        index_exprs.extend(SliceExpr(None, None, None) for _ in range(len(dims) - len(real_indices)))
+
+    # insert placeholder dimensions for indices that are None
+    # in order that we can iterate over dimensions and indices
+    # together below
+    for index, i in enumerate(indices):
+        if isinstance(i, NoneType):
+            dims.insert(index, None)
+
+    if any(isinstance(i, TupleType) or is_array_type(i) for i in indices):
+        return advanced_indexing(indices, dims, index_exprs, type_, ctx)
+
+    return basic_indexing(ctx, dims, index_exprs, indices, type_)
+
+
+def basic_indexing(ctx, dims, index_exprs, indices, type_):
+    return_dims = []
+    if not len(indices) == len(index_exprs) == len(dims): import ipdb; ipdb.set_trace()
+    for dim, index_expr, index in zip(dims, index_exprs, indices):
+        if isinstance(index, NoneType):
+            return_dims.append(LiteralType(1, ctx.api.named_type('builtins.int')))
+        elif isinstance(index, LiteralType):
+            index_value = index.value
+            if index_value >= dim.value:
+                ctx.api.fail(
+                    f'Index {index_value} is out of bounds for axis with size {dim.value}',
+                    ctx.context)
+                return ctx.default_return_type
+        elif is_slice(index):
+            return_dim = get_slice_return_dim(index_expr, dim, ctx)
+            if return_dim is None:
+                return ctx.default_return_type
+            return_dims.append(return_dim)
+        elif is_literal_instance(index):
+            index_value = index.last_known_value.value
+            if index_value >= dim.value:
+                ctx.api.fail(
+                    f'Index {index_value} is out of bounds for axis with size {dim.value}',
+                    ctx.context)
+                return ctx.default_return_type
+        else:
+            return ctx.default_return_type
+    if not return_dims:
+        return type_
+    ndarray = ctx.default_return_type.copy_modified(args=[*return_dims, type_])
+    upper_bound = ctx.api.named_type('builtins.object')
+    add_type_vars_to_array(ndarray, upper_bound)
+    return ndarray
+
+
+class Pax(Plugin):
+    def get_type_analyze_hook(self, fullname: str
+                              ) -> Optional[Callable[[AnalyzeTypeContext], Type]]:
+        if fullname == 'numpy.ndarray':
+            return ndarray_hook
+        if fullname == 'jax.numpy.DeviceArray':
+            return device_array_hook
+        return None
+
+    def get_method_hook(self, fullname: str
+                        ) -> Optional[Callable[[MethodContext], Type]]:
+        if fullname == 'numpy.ndarray.__add__':
+            return functools.partial(add_hook, 'numpy.ndarray')
+        if fullname == 'jax.numpy.DeviceArray.__add__':
+            return functools.partial(add_hook, 'jax.numpy.DeviceArray')
+        if fullname == 'numpy.ndarray.__matmul__':
+            return functools.partial(matmul_hook, 'numpy.ndarray')
+        if fullname == 'jax.numpy.DeviceArray.__matmul__':
+            return functools.partial(matmul_hook, 'jax.numpy.DeviceArray')
+        if fullname in ('numpy.ndarray.__getitem__', 'jax.numpy.DeviceArray.__getitem__'):
+            return get_item_hook
+        if fullname in ('numpy.ndarray.flatten', 'jax.numpy.DeviceArray.flatten'):
+            return flatten_hook
+        if fullname in ('numpy.ndarray.reshape', 'jax.numpy.DeviceArray.reshape'):
+            return reshape_hook
+        return None
+
+    def get_function_hook(self, fullname: str
+                          ) -> Optional[Callable[[FunctionContext], Type]]:
+        if fullname in ('numpy.zeros', 'jax.numpy.zeros'):
+            return zeros_hook
+        if fullname == 'numpy.array':
+            return array_hook
+        return None
+
+
+def plugin(_: Any) -> Type_[Pax]:
+    return Pax

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,414 @@
+[[package]]
+name = "absl-py"
+version = "1.0.0"
+description = "Abseil Python Common Libraries, see https://github.com/abseil/abseil-py."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.2.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "flatbuffers"
+version = "2.0"
+description = "The FlatBuffers serialization format for Python"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "jax"
+version = "0.2.26"
+description = "Differentiate, compile, and transform Numpy code."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+absl-py = "*"
+jaxlib = {version = "0.1.75", optional = true, markers = "extra == \"cpu\""}
+numpy = ">=1.18"
+opt_einsum = "*"
+scipy = ">=1.2.1"
+typing_extensions = "*"
+
+[package.extras]
+cpu = ["jaxlib (==0.1.75)"]
+cuda = ["jaxlib (==0.1.75+cuda11.cudnn82)"]
+cuda11_cudnn805 = ["jaxlib (==0.1.75+cuda11.cudnn805)"]
+cuda11_cudnn82 = ["jaxlib (==0.1.75+cuda11.cudnn82)"]
+minimum-jaxlib = ["jaxlib (==0.1.74)"]
+tpu = ["jaxlib (==0.1.75)", "libtpu-nightly (==0.1.dev20211208)", "requests"]
+
+[[package]]
+name = "jaxlib"
+version = "0.1.75"
+description = "XLA library for JAX"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+absl-py = "*"
+flatbuffers = ">=1.12,<3.0"
+numpy = ">=1.18"
+scipy = "*"
+
+[[package]]
+name = "mypy"
+version = "0.910"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+toml = "*"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "numpy"
+version = "1.21.4"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.7,<3.11"
+
+[[package]]
+name = "opt-einsum"
+version = "3.3.0"
+description = "Optimizing numpys einsum function"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+numpy = ">=1.7"
+
+[package.extras]
+docs = ["sphinx (==1.2.3)", "sphinxcontrib-napoleon", "sphinx-rtd-theme", "numpydoc"]
+tests = ["pytest", "pytest-cov", "pytest-pep8"]
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.6"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "6.2.5"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "scipy"
+version = "1.7.3"
+description = "SciPy: Scientific Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7,<3.11"
+
+[package.dependencies]
+numpy = ">=1.16.5,<1.23.0"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "typing-extensions"
+version = "4.0.0"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[metadata]
+lock-version = "1.1"
+python-versions = ">=3.9,<3.11"
+content-hash = "56d9aec01e5839cd796ba2d21bc7eef85fc33c9da75ae1a747532e8a5a904b18"
+
+[metadata.files]
+absl-py = [
+    {file = "absl-py-1.0.0.tar.gz", hash = "sha256:ac511215c01ee9ae47b19716599e8ccfa746f2e18de72bdf641b79b22afa27ea"},
+    {file = "absl_py-1.0.0-py3-none-any.whl", hash = "sha256:84e6dcdc69c947d0c13e5457d056bd43cade4c2393dce00d684aedea77ddc2a3"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+flatbuffers = [
+    {file = "flatbuffers-2.0-py2.py3-none-any.whl", hash = "sha256:3751954f0604580d3219ae49a85fafec9d85eec599c0b96226e1bc0b48e57474"},
+    {file = "flatbuffers-2.0.tar.gz", hash = "sha256:12158ab0272375eab8db2d663ae97370c33f152b27801fa6024e1d6105fd4dd2"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+jax = [
+    {file = "jax-0.2.26.tar.gz", hash = "sha256:09eb0b5a1ba9675c908bb83b87df27e69a0878a2120f3d56b01a10c1307ac63f"},
+]
+jaxlib = [
+    {file = "jaxlib-0.1.75-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:11b01864871cb44d8b28f854d3d8d41bf7b8a9f6cb55c4e5577fcec270f93a9f"},
+    {file = "jaxlib-0.1.75-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:aae98afae7cc95259a3152b8c4979cf5d5e74b8e482694e2ae7509a9364761d2"},
+    {file = "jaxlib-0.1.75-cp310-none-manylinux2010_x86_64.whl", hash = "sha256:14535c36fa556a2576dd66a4b606371c7a2b221f581872eed0760e962bd814be"},
+    {file = "jaxlib-0.1.75-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:6db43240f92e0c6fd49e946e105fd514a949076421903efc0c250acbed947ca0"},
+    {file = "jaxlib-0.1.75-cp37-none-manylinux2010_x86_64.whl", hash = "sha256:987e7974b054741bbc361a1c51ffd4d9007b3be83b11c3d04bdd6fcd774c59d1"},
+    {file = "jaxlib-0.1.75-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:62051bb817d543c7761d3ab29eef4a9931ff8e9c2e12167c9f93bd1f86f84059"},
+    {file = "jaxlib-0.1.75-cp38-none-manylinux2010_x86_64.whl", hash = "sha256:aa12c2101db4a0639c88c73f8024dfbe2c42e17a46ca9bee2296c8b03bb157fd"},
+    {file = "jaxlib-0.1.75-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:8bf84316a55a8a57539151415177bb171479e26866b3831d3fe6a49ab11ebc0d"},
+    {file = "jaxlib-0.1.75-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:1cb508307f8edee6d46f9d660222299678fb93cf6aeaa2b492e44a7bdf8daf1f"},
+    {file = "jaxlib-0.1.75-cp39-none-manylinux2010_x86_64.whl", hash = "sha256:a61e0eeefa0ccb9ea552cbe06908351bca47861188a902076e28aadd52af5bb5"},
+]
+mypy = [
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+numpy = [
+    {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8890b3360f345e8360133bc078d2dacc2843b6ee6059b568781b15b97acbe39f"},
+    {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:69077388c5a4b997442b843dbdc3a85b420fb693ec8e33020bb24d647c164fa5"},
+    {file = "numpy-1.21.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e89717274b41ebd568cd7943fc9418eeb49b1785b66031bc8a7f6300463c5898"},
+    {file = "numpy-1.21.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b78ecfa070460104934e2caf51694ccd00f37d5e5dbe76f021b1b0b0d221823"},
+    {file = "numpy-1.21.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:615d4e328af7204c13ae3d4df7615a13ff60a49cb0d9106fde07f541207883ca"},
+    {file = "numpy-1.21.4-cp310-cp310-win_amd64.whl", hash = "sha256:1403b4e2181fc72664737d848b60e65150f272fe5a1c1cbc16145ed43884065a"},
+    {file = "numpy-1.21.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:74b85a17528ca60cf98381a5e779fc0264b4a88b46025e6bcbe9621f46bb3e63"},
+    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92aafa03da8658609f59f18722b88f0a73a249101169e28415b4fa148caf7e41"},
+    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5d95668e727c75b3f5088ec7700e260f90ec83f488e4c0aaccb941148b2cd377"},
+    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5162ec777ba7138906c9c274353ece5603646c6965570d82905546579573f73"},
+    {file = "numpy-1.21.4-cp37-cp37m-win32.whl", hash = "sha256:81225e58ef5fce7f1d80399575576fc5febec79a8a2742e8ef86d7b03beef49f"},
+    {file = "numpy-1.21.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32fe5b12061f6446adcbb32cf4060a14741f9c21e15aaee59a207b6ce6423469"},
+    {file = "numpy-1.21.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c449eb870616a7b62e097982c622d2577b3dbc800aaf8689254ec6e0197cbf1e"},
+    {file = "numpy-1.21.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2e4ed57f45f0aa38beca2a03b6532e70e548faf2debbeb3291cfc9b315d9be8f"},
+    {file = "numpy-1.21.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1247ef28387b7bb7f21caf2dbe4767f4f4175df44d30604d42ad9bd701ebb31f"},
+    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34f3456f530ae8b44231c63082c8899fe9c983fd9b108c997c4b1c8c2d435333"},
+    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4c9c23158b87ed0e70d9a50c67e5c0b3f75bcf2581a8e34668d4e9d7474d76c6"},
+    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4799be6a2d7d3c33699a6f77201836ac975b2e1b98c2a07f66a38f499cb50ce"},
+    {file = "numpy-1.21.4-cp38-cp38-win32.whl", hash = "sha256:bc988afcea53e6156546e5b2885b7efab089570783d9d82caf1cfd323b0bb3dd"},
+    {file = "numpy-1.21.4-cp38-cp38-win_amd64.whl", hash = "sha256:170b2a0805c6891ca78c1d96ee72e4c3ed1ae0a992c75444b6ab20ff038ba2cd"},
+    {file = "numpy-1.21.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fde96af889262e85aa033f8ee1d3241e32bf36228318a61f1ace579df4e8170d"},
+    {file = "numpy-1.21.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c885bfc07f77e8fee3dc879152ba993732601f1f11de248d4f357f0ffea6a6d4"},
+    {file = "numpy-1.21.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e6f5f50d1eff2f2f752b3089a118aee1ea0da63d56c44f3865681009b0af162"},
+    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad010846cdffe7ec27e3f933397f8a8d6c801a48634f419e3d075db27acf5880"},
+    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c74c699b122918a6c4611285cc2cad4a3aafdb135c22a16ec483340ef97d573c"},
+    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9864424631775b0c052f3bd98bc2712d131b3e2cd95d1c0c68b91709170890b0"},
+    {file = "numpy-1.21.4-cp39-cp39-win32.whl", hash = "sha256:b1e2312f5b8843a3e4e8224b2b48fe16119617b8fc0a54df8f50098721b5bed2"},
+    {file = "numpy-1.21.4-cp39-cp39-win_amd64.whl", hash = "sha256:e3c3e990274444031482a31280bf48674441e0a5b55ddb168f3a6db3e0c38ec8"},
+    {file = "numpy-1.21.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a3deb31bc84f2b42584b8c4001c85d1934dbfb4030827110bc36bfd11509b7bf"},
+    {file = "numpy-1.21.4.zip", hash = "sha256:e6c76a87633aa3fa16614b61ccedfae45b91df2767cf097aa9c933932a7ed1e0"},
+]
+opt-einsum = [
+    {file = "opt_einsum-3.3.0-py3-none-any.whl", hash = "sha256:2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147"},
+    {file = "opt_einsum-3.3.0.tar.gz", hash = "sha256:59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
+    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
+]
+pytest = [
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+scipy = [
+    {file = "scipy-1.7.3-1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:c9e04d7e9b03a8a6ac2045f7c5ef741be86727d8f49c45db45f244bdd2bcff17"},
+    {file = "scipy-1.7.3-1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:b0e0aeb061a1d7dcd2ed59ea57ee56c9b23dd60100825f98238c06ee5cc4467e"},
+    {file = "scipy-1.7.3-1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:b78a35c5c74d336f42f44106174b9851c783184a85a3fe3e68857259b37b9ffb"},
+    {file = "scipy-1.7.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:173308efba2270dcd61cd45a30dfded6ec0085b4b6eb33b5eb11ab443005e088"},
+    {file = "scipy-1.7.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:21b66200cf44b1c3e86495e3a436fc7a26608f92b8d43d344457c54f1c024cbc"},
+    {file = "scipy-1.7.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ceebc3c4f6a109777c0053dfa0282fddb8893eddfb0d598574acfb734a926168"},
+    {file = "scipy-1.7.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7eaea089345a35130bc9a39b89ec1ff69c208efa97b3f8b25ea5d4c41d88094"},
+    {file = "scipy-1.7.3-cp310-cp310-win_amd64.whl", hash = "sha256:304dfaa7146cffdb75fbf6bb7c190fd7688795389ad060b970269c8576d038e9"},
+    {file = "scipy-1.7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:033ce76ed4e9f62923e1f8124f7e2b0800db533828c853b402c7eec6e9465d80"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4d242d13206ca4302d83d8a6388c9dfce49fc48fdd3c20efad89ba12f785bf9e"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8499d9dd1459dc0d0fe68db0832c3d5fc1361ae8e13d05e6849b358dc3f2c279"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca36e7d9430f7481fc7d11e015ae16fbd5575615a8e9060538104778be84addf"},
+    {file = "scipy-1.7.3-cp37-cp37m-win32.whl", hash = "sha256:e2c036492e673aad1b7b0d0ccdc0cb30a968353d2c4bf92ac8e73509e1bf212c"},
+    {file = "scipy-1.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:866ada14a95b083dd727a845a764cf95dd13ba3dc69a16b99038001b05439709"},
+    {file = "scipy-1.7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:65bd52bf55f9a1071398557394203d881384d27b9c2cad7df9a027170aeaef93"},
+    {file = "scipy-1.7.3-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:f99d206db1f1ae735a8192ab93bd6028f3a42f6fa08467d37a14eb96c9dd34a3"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5f2cfc359379c56b3a41b17ebd024109b2049f878badc1e454f31418c3a18436"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb7ae2c4dbdb3c9247e07acc532f91077ae6dbc40ad5bd5dca0bb5a176ee9bda"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c2d250074cfa76715d58830579c64dff7354484b284c2b8b87e5a38321672c"},
+    {file = "scipy-1.7.3-cp38-cp38-win32.whl", hash = "sha256:87069cf875f0262a6e3187ab0f419f5b4280d3dcf4811ef9613c605f6e4dca95"},
+    {file = "scipy-1.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:7edd9a311299a61e9919ea4192dd477395b50c014cdc1a1ac572d7c27e2207fa"},
+    {file = "scipy-1.7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eef93a446114ac0193a7b714ce67659db80caf940f3232bad63f4c7a81bc18df"},
+    {file = "scipy-1.7.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:eb326658f9b73c07081300daba90a8746543b5ea177184daed26528273157294"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93378f3d14fff07572392ce6a6a2ceb3a1f237733bd6dcb9eb6a2b29b0d19085"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edad1cf5b2ce1912c4d8ddad20e11d333165552aba262c882e28c78bbc09dbf6"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d1cc2c19afe3b5a546ede7e6a44ce1ff52e443d12b231823268019f608b9b12"},
+    {file = "scipy-1.7.3-cp39-cp39-win32.whl", hash = "sha256:2c56b820d304dffcadbbb6cbfbc2e2c79ee46ea291db17e288e73cd3c64fefa9"},
+    {file = "scipy-1.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:3f78181a153fa21c018d346f595edd648344751d7f03ab94b398be2ad083ed3e"},
+    {file = "scipy-1.7.3.tar.gz", hash = "sha256:ab5875facfdef77e0a47d5fd39ea178b58e60e454a4c85aa1e52fcb80db7babf"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.0.0-py3-none-any.whl", hash = "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"},
+    {file = "typing_extensions-4.0.0.tar.gz", hash = "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+name = "pax"
+version = "0.0.1"
+description = ""
+authors = ["Sune Debel <sune.debel@omhu.com>"]
+include = ["numpy-stubs", "jax-stubs"]
+
+[tool.poetry.dependencies]
+python = ">=3.9,<3.11"
+jax = "^0.2.26"
+
+[tool.poetry.dev-dependencies]
+mypy = "^0.910"
+numpy = "^1.21.4"
+pytest = "^6.2.5"
+jax = {extras = ["cpu"], version = "^0.2.26"}
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.mypy]
+plugins = ["pax"]

--- a/tests/test_jax_stubs.pyi
+++ b/tests/test_jax_stubs.pyi
@@ -1,0 +1,71 @@
+from typing import Literal, Final, Any
+import jax.numpy as jnp
+
+zero_final: Final = 0
+one_final: Final = 1
+two_final: Final = 2
+three_final: Final = 3
+four_final: Final = 4
+
+zero: Literal[0] = 0
+one: Literal[1] = 1
+two: Literal[2] = 2
+three: Literal[3] = 3
+four: Literal[4] = 4
+
+
+# Test DeviceArray analyze_type hook
+a: jnp.DeviceArray[Literal[2], Literal[2], jnp.float32]
+b: jnp.DeviceArray[Literal[2], Literal[1], jnp.float32]
+c: jnp.DeviceArray[Any, Any]
+d: jnp.DeviceArray[Any, str]  # error: Type argument "builtins.str" of "DeviceArray" must be a subtype of "Union[jax.numpy.float32, jax.numpy.int32, Union[numpy.float64, numpy.float32, numpy.float16, numpy.float8, numpy.int64, numpy.int32, numpy.int16, numpy.int8, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.bool_, numpy.complex64, numpy.complex128, numpy.complex192, numpy.complex256, numpy.void, numpy.str_]]"
+
+reveal_type(a)  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32]"
+reveal_type(b)  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], Literal[1], jax.numpy.float32]"
+reveal_type(c)  # note: Revealed type is "jax.numpy.DeviceArray[Any, Any]"
+reveal_type(d)  # note: Revealed type is "jax.numpy.DeviceArray[Any, builtins.str]"
+
+
+# Test ndarray.__matmul__ hook
+reveal_type(a @ b)  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], Literal[1], jax.numpy.float32]"
+a @ jnp.zeros((3, 1))  # error: Unsupported operand type for @ ("jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32]" and "jax.numpy.DeviceArray[Literal[3], Literal[1], jax.numpy.float32]" because dimensions Literal[2] and Literal[3] are incompatible)
+
+
+# Test ndarray.__add__ hook
+reveal_type(a + b)  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32]"
+a + jnp.zeros((3, 3))  # error: Unsupported operand type for + ("jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32]" and "jax.numpy.DeviceArray[Literal[3], Literal[3], jax.numpy.float32]" because dimensions Literal[2] and Literal[3] are incompatible)
+
+# Test type annotation of ndarray.__pos__
+reveal_type(+a)  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32]"
+
+# Test zeros hook
+reveal_type(jnp.zeros((1, 2)))  # note: Revealed type is "jax.numpy.DeviceArray[Literal[1], Literal[2], jax.numpy.float32]"
+reveal_type(jnp.zeros((one_final, two_final)))  # note: Revealed type is "jax.numpy.DeviceArray[Literal[1], Literal[2], jax.numpy.float32]"
+reveal_type(jnp.zeros((one, two)))  # note: Revealed type is "jax.numpy.DeviceArray[Literal[1], Literal[2], jax.numpy.float32]"
+
+# Test flatten hook
+reveal_type(a.flatten())  # note: Revealed type is "jax.numpy.DeviceArray[Literal[4], jax.numpy.float32]"
+
+# Test reshape hook
+reveal_type(a.reshape((4, 1)))  # note: Revealed type is "jax.numpy.DeviceArray[Literal[4], Literal[1], jax.numpy.float32]"
+reveal_type(a.reshape((four_final, one_final)))  # note: Revealed type is "jax.numpy.DeviceArray[Literal[4], Literal[1], jax.numpy.float32]"
+reveal_type(a.reshape((four, one)))  # note: Revealed type is "jax.numpy.DeviceArray[Literal[4], Literal[1], jax.numpy.float32]"
+
+# test that return values of np.array can be annotated to arbitrary shape
+_: jnp.DeviceArray[Literal[2], Literal[2], jnp.float32] = jnp.array([])
+
+# Test ndarray.__getitem__ with basic indexing
+reveal_type(a[:])  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32]"
+reveal_type(a[0, :])  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], jax.numpy.float32]"
+reveal_type(a[zero_final, :])  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], jax.numpy.float32]"
+reveal_type(a[zero, :])  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], jax.numpy.float32]"
+reveal_type(a[0, ...]) # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], jax.numpy.float32]"
+reveal_type(a[zero_final, ...]) # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], jax.numpy.float32]"
+reveal_type(a[zero, ...]) # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], jax.numpy.float32]"
+reveal_type(a[zero, jnp.newaxis]) # note: Revealed type is "jax.numpy.DeviceArray[Literal[1], Literal[2], jax.numpy.float32]"
+reveal_type(a[0:1])  # note: Revealed type is "jax.numpy.DeviceArray[Literal[1], Literal[2], jax.numpy.float32]"
+reveal_type(a[0:5])  # note: Revealed type is "jax.numpy.DeviceArray[Literal[2], Literal[2], jax.numpy.float32]"
+a[:, :, :]  # error: Too many indices: array is 2-dimensional, but 3 were indexed
+a[3]  # error: Index 3 is out of bounds for axis with size 2
+a[three_final] # error: Index 3 is out of bounds for axis with size 2
+a[three] # error: Index 3 is out of bounds for axis with size 2

--- a/tests/test_numpy_stubs.pyi
+++ b/tests/test_numpy_stubs.pyi
@@ -1,0 +1,107 @@
+from typing import Literal, Final, Any
+import numpy as np
+
+zero_final: Final = 0
+one_final: Final = 1
+two_final: Final = 2
+three_final: Final = 3
+four_final: Final = 4
+
+zero: Literal[0] = 0
+one: Literal[1] = 1
+two: Literal[2] = 2
+three: Literal[3] = 3
+four: Literal[4] = 4
+
+
+# Test ndarray analyze_type hook
+a: np.ndarray[Literal[2], Literal[2], np.float64]
+b: np.ndarray[Literal[2], Literal[1], np.float64]
+c: np.ndarray[Any, Any]
+d: np.ndarray[Any, str]  # error: Type argument "builtins.str" of "ndarray" must be a subtype of "Union[numpy.float64, numpy.float32, numpy.float16, numpy.float8, numpy.int64, numpy.int32, numpy.int16, numpy.int8, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.bool_, numpy.complex64, numpy.complex128, numpy.complex192, numpy.complex256, numpy.void, numpy.str_]"
+
+reveal_type(a)  # note: Revealed type is "numpy.ndarray[Literal[2], Literal[2], numpy.float64]"
+reveal_type(b)  # note: Revealed type is "numpy.ndarray[Literal[2], Literal[1], numpy.float64]"
+reveal_type(c)  # note: Revealed type is "numpy.ndarray[Any, Any]"
+reveal_type(d)  # note: Revealed type is "numpy.ndarray[Any, builtins.str]"
+
+
+# Test ndarray.__matmul__ hook
+reveal_type(a @ b)  # note: Revealed type is "numpy.ndarray[Literal[2], Literal[1], numpy.float64]"
+a @ np.zeros((3, 1))  # error: Unsupported operand type for @ ("numpy.ndarray[Literal[2], Literal[2], numpy.float64]" and "numpy.ndarray[Literal[3], Literal[1], numpy.float64]" because dimensions Literal[2] and Literal[3] are incompatible)
+
+
+# Test ndarray.__add__ hook
+reveal_type(a + b)  # note: Revealed type is "numpy.ndarray[Literal[2], Literal[2], numpy.float64]"
+a + np.zeros((3, 3))  # error: Unsupported operand type for + ("numpy.ndarray[Literal[2], Literal[2], numpy.float64]" and "numpy.ndarray[Literal[3], Literal[3], numpy.float64]" because dimensions Literal[2] and Literal[3] are incompatible)
+
+
+# Test type annotation of ndarray.__pos__
+reveal_type(+a)  # note: Revealed type is "numpy.ndarray[Literal[2], Literal[2], numpy.float64]"
+
+# Test zeros hook
+reveal_type(np.zeros((1, 2)))  # note: Revealed type is "numpy.ndarray[Literal[1], Literal[2], numpy.float64]"
+reveal_type(np.zeros((one_final, two_final)))  # note: Revealed type is "numpy.ndarray[Literal[1], Literal[2], numpy.float64]"
+reveal_type(np.zeros((one, two)))  # note: Revealed type is "numpy.ndarray[Literal[1], Literal[2], numpy.float64]"
+
+
+# Test flatten hook
+reveal_type(a.flatten())  # note: Revealed type is "numpy.ndarray[Literal[4], numpy.float64]"
+
+
+# Test reshape hook
+reveal_type(a.reshape((4, 1)))  # note: Revealed type is "numpy.ndarray[Literal[4], Literal[1], numpy.float64]"
+reveal_type(a.reshape((four_final, one_final)))  # note: Revealed type is "numpy.ndarray[Literal[4], Literal[1], numpy.float64]"
+reveal_type(a.reshape((four, one)))  # note: Revealed type is "numpy.ndarray[Literal[4], Literal[1], numpy.float64]"
+
+
+# test that return values of np.array can be annotated to arbitrary shape
+_: np.ndarray[Literal[2], Literal[2], np.float64] = np.array([])
+
+
+# Test ndarray.__getitem__ with basic indexing
+reveal_type(a[:])  # note: Revealed type is "numpy.ndarray[Literal[2], Literal[2], numpy.float64]"
+reveal_type(a[0, :])  # note: Revealed type is "numpy.ndarray[Literal[2], numpy.float64]"
+reveal_type(a[zero_final, :])  # note: Revealed type is "numpy.ndarray[Literal[2], numpy.float64]"
+reveal_type(a[zero, :])  # note: Revealed type is "numpy.ndarray[Literal[2], numpy.float64]"
+reveal_type(a[0, ...]) # note: Revealed type is "numpy.ndarray[Literal[2], numpy.float64]"
+reveal_type(a[zero_final, ...]) # note: Revealed type is "numpy.ndarray[Literal[2], numpy.float64]"
+reveal_type(a[zero, ...]) # note: Revealed type is "numpy.ndarray[Literal[2], numpy.float64]"
+reveal_type(a[zero, np.newaxis]) # note: Revealed type is "numpy.ndarray[Literal[1], Literal[2], numpy.float64]"
+reveal_type(a[0:1])  # note: Revealed type is "numpy.ndarray[Literal[1], Literal[2], numpy.float64]"
+reveal_type(a[0:5])  # note: Revealed type is "numpy.ndarray[Literal[2], Literal[2], numpy.float64]"
+a[:, :, :]  # error: Too many indices: array is 2-dimensional, but 3 were indexed
+a[3]  # error: Index 3 is out of bounds for axis with size 2
+a[three_final] # error: Index 3 is out of bounds for axis with size 2
+a[three] # error: Index 3 is out of bounds for axis with size 2
+
+
+# Test ndarray.__getitem__ with advanced indexing
+i = np.zeros((3, 3), dtype=np.int64)
+i2 = np.zeros((3, 4), dtype=np.int64)
+reveal_type(a[np.newaxis, i]) # note: Revealed type is "numpy.ndarray[Literal[1], Literal[3], Literal[3], Literal[2], numpy.float64]"
+a[np.zeros((3, 3))]  # error: Arrays used as indices must be of integer (or boolean) type
+reveal_type(a[i])  # note: Revealed type is "numpy.ndarray[Literal[3], Literal[3], Literal[2], numpy.float64]"
+reveal_type(a[i, i])  # note: Revealed type is "numpy.ndarray[Literal[3], Literal[3], numpy.float64]"
+a[i, i2]  # error: broadcast error
+reveal_type(a[(0, 1, 0),])  # note: Revealed type is "numpy.ndarray[Literal[3], Literal[2], numpy.float64]"
+reveal_type(a[(zero_final, one_final, zero_final),])  # note: Revealed type is "numpy.ndarray[Literal[3], Literal[2], numpy.float64]"
+reveal_type(a[(zero, one, zero),])  # note: Revealed type is "numpy.ndarray[Literal[3], Literal[2], numpy.float64]"
+reveal_type(a[(0, 1, 0), (0, 1, 0)])  # note: Revealed type is "numpy.ndarray[Literal[3], numpy.float64]"
+reveal_type(a[(0, 1, 0), 1])  # note: Revealed type is "numpy.ndarray[Literal[3], numpy.float64]"
+reveal_type(a[(0, 1, 0), one_final])  # note: Revealed type is "numpy.ndarray[Literal[3], numpy.float64]"
+reveal_type(a[(0, 1, 0), one])  # note: Revealed type is "numpy.ndarray[Literal[3], numpy.float64]"
+reveal_type(a[(0, 1, 0), 0:1])  # note: Revealed type is "numpy.ndarray[Literal[3], Literal[1], numpy.float64]"
+reveal_type(a[(0, 1, 0), 0:5])  # note: Revealed type is "numpy.ndarray[Literal[3], Literal[2], numpy.float64]"
+reveal_type(a[(0, 1, 0), np.newaxis, 1]) # note: Revealed type is "numpy.ndarray[Literal[3], Literal[1], numpy.float64]"
+a[(0, 2),]  # error: Index 2 is out of bounds for axis with size 2
+a[(0, 1), 2]  # error: Index 2 is out of bounds for axis with size 2
+
+
+# Test dtype conversion
+a = np.zeros((2, 2), dtype=np.float32)
+b = np.zeros((2, 2), dtype=np.int64)
+reveal_type(a + b)  # note: Revealed type is "numpy.ndarray[Literal[2], Literal[2], numpy.float64]"
+a + np.array([], dtype=np.str_)  # error: Incompatible scalar types ("numpy.float32*" and "numpy.str_")
+
+


### PR DESCRIPTION
Adds the following `mypy` hooks:
- Type analysis of `numpy.ndarray` and `jax.numpy.DeviceArray`
- Return type/argument checking hook of `__add__` for `numpy.ndarray` and `jax.numpy.DeviceArray`
- Return type/argument checking hook of `__matmul__` for `numpy.ndarray` and `jax.numpy.DeviceArray`
- Return type hook for `zeros` of `numpy` and `jax.numpy`
- Return type hook of `flatten` of `numpy.ndarray` and `jax.numpy.DeviceArray`
- Return type hook of `reshape` and `numpy.ndarray` and `jax.numpy.DeviceArray`
- Return type/argument checking hook of `__getitem__` for `numpy.ndarray` and `jax.numpy.DeviceArray`